### PR TITLE
add support for discourse context

### DIFF
--- a/api/query/post.ts
+++ b/api/query/post.ts
@@ -48,11 +48,7 @@ const logic = async ({
   if (targetConditions.length === 0) {
     return queryRoam({
       authorization,
-      body: {
-        conditions: body.conditions,
-        returnNode: body.returnNode,
-        selections: body.selections,
-      },
+      body: { ...body }, // TODO type fix
     });
   }
   // TODO - support multiple targets
@@ -79,8 +75,19 @@ const logic = async ({
   );
 };
 
+const dgraphSchema = notebookRequestNodeQuerySchema.extend({
+  context: z
+    .object({
+      relationsInQuery: z.array(z.any()).optional().default([]),
+      customNodes: z.array(z.any()).optional().default([]),
+      customRelations: z.array(z.any()).optional().default([]),
+    })
+    .optional()
+    .default({}),
+});
+
 export default createAPIGatewayProxyHandler({
   logic,
-  bodySchema,
+  bodySchema: dgraphSchema.omit({ schema: true }),
   allowedOrigins: [/roamresearch\.com/],
 });

--- a/src/utils/compileDatalog.ts
+++ b/src/utils/compileDatalog.ts
@@ -13,7 +13,7 @@ import {
 
 const indent = (n: number) => "".padStart(n * 2, " ");
 
-const toVar = (v = "undefined") => v.replace(/[\s"()[\]{}/\\]/g, "");
+const toVar = (v = "undefined") => v.replace(/[\s"()[\]{}/\\^@,~`]/g, "");
 
 // TODO - look into an edn library instead: edn.stringify(data, null, 2)
 const compileDatalog = (
@@ -77,9 +77,9 @@ const compileDatalog = (
     case "pattern-name":
       return d.value;
     case "pull-expression":
-      return `${indent(level)}[pull ${compileDatalog(
+      return `${indent(level)}(pull ${compileDatalog(
         d.variable
-      )} ${compileDatalog(d.pattern)}\n${indent(level)}]`;
+      )} ${compileDatalog(d.pattern)}\n${indent(level)})`;
     case "aggregate":
       return `[${d.name} ${d.args.map((a) => compileDatalog(a)).join(" ")}]`;
     case "attr-name":

--- a/src/utils/isBlock.ts
+++ b/src/utils/isBlock.ts
@@ -1,3 +1,10 @@
+export const isBlockBackend = async (uid: string) => {
+  const result = await window.roamAlphaAPI.data.fast.q(
+    `[:find ?id :where [?id :block/uid "${uid}"]]`
+  );
+  return !!result?.[0]?.[0];
+};
+
 const isBlock = (notebookPageId: string) =>
   !!window.roamAlphaAPI.pull("[:db/id]", [":block/uid", notebookPageId]);
 

--- a/src/utils/isPage.ts
+++ b/src/utils/isPage.ts
@@ -1,3 +1,10 @@
+export const isPageBackend = async (title: string) => {
+  const result = await window.roamAlphaAPI.data.fast.q(
+    `[:find ?id :where [?id :node/title "${title}"]]`
+  )?.[0]?.[0];
+  return !!result;
+};
+
 const isPage = (notebookPageId: string) =>
   !!window.roamAlphaAPI.pull("[:db/id]", [":node/title", notebookPageId]);
 

--- a/src/utils/registerDiscourseDatalogTranslators.ts
+++ b/src/utils/registerDiscourseDatalogTranslators.ts
@@ -1,0 +1,424 @@
+import {
+  DatalogAndClause,
+  DatalogClause,
+  DatalogVariable,
+} from "roamjs-components/types";
+import {
+  DiscourseRelation,
+  RelationType,
+  Translator,
+  TranslatorContext,
+  conditionToDatalog,
+  translator,
+} from "./getDatalogQuery";
+import { nanoid } from "nanoid";
+import { isBlockBackend } from "./isBlock";
+import { isPageBackend } from "./isPage";
+
+const ANY_RELATION_REGEX = /Has Any Relation To/i;
+type CombinedRelationType = {
+  text: string;
+  id: string;
+  relation: DiscourseRelation[];
+  isComplement?: boolean;
+};
+type ForwardType = DiscourseRelation & { forward: boolean };
+
+const collectVariables = (
+  clauses: (DatalogClause | DatalogAndClause)[]
+): Set<string> =>
+  new Set(
+    clauses.flatMap((c) => {
+      switch (c.type) {
+        case "data-pattern":
+        case "fn-expr":
+        case "pred-expr":
+        case "rule-expr":
+          return [...c.arguments]
+            .filter((a) => a.type === "variable")
+            .map((a) => a.value);
+        case "not-join-clause":
+        case "or-join-clause":
+        case "not-clause":
+        case "or-clause":
+        case "and-clause":
+          return Array.from(collectVariables(c.clauses));
+        default:
+          return [];
+      }
+    })
+  );
+
+const replaceDatalogVariables = (
+  replacements: (
+    | { from: string; to: string }
+    | { from: true; to: (v: string) => string }
+  )[] = [],
+  clauses: DatalogClause[]
+): DatalogClause[] => {
+  const replaceDatalogVariable = (a: DatalogVariable): DatalogVariable => {
+    const rep = replacements.find(
+      (rep) => a.value === rep.from || rep.from === true
+    );
+    if (!rep) {
+      return { ...a };
+    } else if (a.value === rep.from) {
+      a.value = rep.to;
+      return {
+        ...a,
+        value: rep.to,
+      };
+    } else if (rep.from === true) {
+      return {
+        ...a,
+        value: rep.to(a.value),
+      };
+    }
+    return a;
+  };
+  return clauses.map((c): DatalogClause => {
+    switch (c.type) {
+      case "data-pattern":
+      case "fn-expr":
+      case "pred-expr":
+      case "rule-expr":
+        return {
+          ...c,
+          arguments: c.arguments.map((a) => {
+            if (a.type !== "variable") {
+              return { ...a };
+            }
+            return replaceDatalogVariable(a);
+          }),
+          ...(c.type === "fn-expr"
+            ? {
+                binding:
+                  c.binding.type === "bind-scalar"
+                    ? {
+                        variable: replaceDatalogVariable(c.binding.variable),
+                        type: "bind-scalar",
+                      }
+                    : c.binding,
+              }
+            : {}),
+        };
+      case "not-join-clause":
+      case "or-join-clause":
+        return {
+          ...c,
+          variables: c.variables.map(replaceDatalogVariable),
+          clauses: replaceDatalogVariables(replacements, c.clauses),
+        };
+      case "not-clause":
+      case "or-clause":
+      case "and-clause":
+        return {
+          ...c,
+          clauses: replaceDatalogVariables(replacements, c.clauses),
+        };
+      default:
+        throw new Error(`Unknown clause type: ${c["type"]}`);
+    }
+  });
+};
+
+const computeEdgeTriple = ({
+  nodeType,
+  value,
+  triple,
+  context,
+}: {
+  nodeType: string;
+  value: string;
+  triple: readonly [string, string, string];
+  context: TranslatorContext;
+}): DatalogClause[] => {
+  const { nodeTypes } = context;
+  const nodeTypeByLabel = Object.fromEntries(
+    nodeTypes.map((n) => [n.text.toLowerCase(), n.id])
+  );
+  const possibleNodeType = nodeTypeByLabel[value.toLowerCase()];
+  if (possibleNodeType) {
+    const condition = conditionToDatalog({
+      condition: {
+        target: possibleNodeType,
+        relation: "is a",
+        source: triple[0],
+        type: "AND",
+      },
+      context,
+    });
+    return condition;
+  } else if (isBlockBackend(value).then((isBlock) => isBlock)) {
+    return [
+      {
+        type: "data-pattern",
+        arguments: [
+          { type: "variable", value: triple[0] },
+          { type: "constant", value: ":block/uid" },
+          { type: "constant", value: `"${value}"` },
+        ],
+      },
+    ];
+  } else if (isPageBackend(value).then((isPage) => isPage)) {
+    const condition = conditionToDatalog({
+      condition: {
+        target: value,
+        relation: "has title",
+        source: triple[0],
+        type: "AND",
+      },
+      context,
+    });
+    return condition;
+  } else {
+    const condition = conditionToDatalog({
+      condition: {
+        target: nodeType,
+        relation: "is a",
+        source: triple[0],
+        type: "AND",
+      },
+      context,
+    });
+    return condition;
+  }
+};
+const generateEdgeTriples = ({
+  forward,
+  source,
+  target,
+  sourceTriple,
+  targetTriple,
+  relationSource,
+  relationTarget,
+  context,
+}: {
+  forward: boolean;
+  source: string;
+  target: string;
+  sourceTriple: readonly [string, string, string];
+  targetTriple: readonly [string, string, string];
+  relationSource: string;
+  relationTarget: string;
+  context: TranslatorContext;
+}): DatalogClause[] => {
+  const firstDataPatternVariable = forward ? sourceTriple[0] : targetTriple[0];
+  const secondDataPatternVariable = forward ? targetTriple[0] : sourceTriple[0];
+  return computeEdgeTriple({
+    value: forward ? source : target,
+    triple: sourceTriple,
+    nodeType: relationSource,
+    context,
+  })
+    .concat(
+      computeEdgeTriple({
+        value: forward ? target : source,
+        triple: targetTriple,
+        nodeType: relationTarget,
+        context,
+      })
+    )
+    .concat([
+      {
+        type: "data-pattern",
+        arguments: [
+          { type: "variable", value: firstDataPatternVariable },
+          { type: "constant", value: ":block/uid" },
+          { type: "variable", value: `${source}-uid` },
+        ],
+      },
+      {
+        type: "data-pattern",
+        arguments: [
+          { type: "variable", value: source },
+          { type: "constant", value: ":block/uid" },
+          { type: "variable", value: `${source}-uid` },
+        ],
+      },
+      {
+        type: "data-pattern",
+        arguments: [
+          { type: "variable", value: secondDataPatternVariable },
+          { type: "constant", value: ":block/uid" },
+          { type: "variable", value: `${target}-uid` },
+        ],
+      },
+      {
+        type: "data-pattern",
+        arguments: [
+          { type: "variable", value: target },
+          { type: "constant", value: ":block/uid" },
+          { type: "variable", value: `${target}-uid` },
+        ],
+      },
+    ]);
+};
+const generateAndParts = ({
+  filteredRelations,
+  source,
+  target,
+  context,
+}: {
+  filteredRelations: ForwardType[];
+  source: string;
+  target: string;
+  context: TranslatorContext;
+}) => {
+  return filteredRelations.map((relation) => {
+    const {
+      triples,
+      source: relationSource,
+      destination: relationTarget,
+      forward,
+    } = relation;
+    const sourceTriple = triples.find((t) => t[2] === "source");
+    const targetTriple = triples.find(
+      (t) => t[2] === "destination" || t[2] === "target"
+    );
+    if (!sourceTriple || !targetTriple) return [];
+
+    const edgeTriples = generateEdgeTriples({
+      forward,
+      source,
+      target,
+      sourceTriple,
+      targetTriple,
+      relationSource,
+      relationTarget,
+      context,
+    });
+    const subQuery = triples
+      .filter((t) => t !== sourceTriple && t !== targetTriple)
+      .flatMap(([src, rel, tar]) =>
+        conditionToDatalog({
+          condition: {
+            type: "AND",
+            source: src,
+            relation: rel,
+            target: tar,
+          },
+          context,
+        })
+      );
+    const id = nanoid(9);
+    return replaceDatalogVariables(
+      [
+        { from: source, to: source },
+        { from: target, to: target },
+        { from: true, to: (v) => `${id}-${v}` },
+      ],
+      edgeTriples.concat(subQuery)
+    );
+  });
+};
+
+const register = ({ key, ...translation }: Translator & { key: string }) => {
+  translator[key] = translation;
+};
+const registerDiscourseDatalogTranslator = (
+  context: TranslatorContext
+): null => {
+  const { relationTypes, relationsInQuery } = context;
+
+  const relationTypesWithComplementTypes = new Set(
+    relationTypes.flatMap((relationType) => {
+      const { ...rest } = relationType;
+      const relation: RelationType = {
+        ...rest,
+        isComplement: false,
+      };
+      const swappedRelation: RelationType = {
+        ...rest,
+        text: relationType.relation.complement,
+        isComplement: true,
+      };
+      return [relation, swappedRelation];
+    })
+  );
+
+  const groupRelations = (
+    relations: RelationType[]
+  ): CombinedRelationType[] => {
+    const grouped: { [key: string]: CombinedRelationType } = {};
+
+    relations.forEach((relation) => {
+      const key = `${relation.id}-${relation.isComplement}`;
+      if (!grouped[key]) {
+        grouped[key] = {
+          text: relation.text,
+          id: relation.id,
+          relation: [relation.relation],
+          isComplement: relation.isComplement,
+        };
+      } else {
+        grouped[key].relation.push(relation.relation);
+      }
+    });
+
+    return Object.values(grouped);
+  };
+
+  const requiredRelations = groupRelations(
+    Array.from(relationTypesWithComplementTypes).filter(({ id }) =>
+      relationsInQuery.some((r) => r.id === id)
+    )
+  );
+
+  requiredRelations.forEach((r) => {
+    const { text, isComplement } = r;
+    const isRelationInTranslator = !!translator[text];
+    if (isRelationInTranslator) return null;
+
+    register({
+      key: text.toLowerCase(),
+      callback: ({
+        source,
+        target,
+        context,
+      }: {
+        source: string;
+        target: string;
+        context: TranslatorContext;
+      }) => {
+        const forwardType = r.relation.map((rel) => ({
+          ...rel,
+          forward: !r.isComplement,
+        }));
+
+        const andParts = generateAndParts({
+          filteredRelations: forwardType,
+          source,
+          target,
+          context,
+        });
+        if (andParts.length === 1) return andParts[0];
+
+        const orJoinedVars = collectVariables(andParts[0]);
+        andParts.slice(1).forEach((a) => {
+          const freeVars = collectVariables(a);
+          Array.from(orJoinedVars).forEach((v) => {
+            if (!freeVars.has(v)) orJoinedVars.delete(v);
+          });
+        });
+        return [
+          {
+            type: "or-join-clause",
+            variables: Array.from(orJoinedVars).map((v) => ({
+              type: "variable",
+              value: v,
+            })),
+            clauses: andParts.map((a) => ({
+              type: "and-clause",
+              clauses: a,
+            })),
+          },
+        ];
+      },
+    });
+  });
+
+  return null;
+};
+
+export default registerDiscourseDatalogTranslator;


### PR DESCRIPTION
maybe not blocking, but here are some unfinished tasks related to this
- [ ] error handling: node specification required
- [ ] error handling: user know if the limit has been reached
- [ ] Front end:  `specification` currently does not supports using variables `{Source}`

re: api limit
- [ ] break apart: `processQueries()` on the front end and send all queries at the same time, and use Roam's `batch queries`?

related front end PR: https://github.com/RoamJS/query-builder/pull/268

https://www.loom.com/share/6fb2368c635b4cd5b1c25e5b884027ae

2024-06-28
- [ ] return `text-uid`

we also need to transform the results to be able to navigate to the page after clicking on it
in the front end this is done here:
https://github.com/RoamJS/query-builder/blob/6d9c7e50ee69c02b9069b9b12277fcf3cff52203/src/utils/fireQuery.ts#L261-L296

